### PR TITLE
Add model module with sample dataset and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/data/bank_churn.csv
+++ b/data/bank_churn.csv
@@ -1,0 +1,11 @@
+RowNumber,CustomerId,Surname,CreditScore,Geography,Gender,Age,Tenure,Balance,NumOfProducts,HasCrCard,IsActiveMember,EstimatedSalary,Exited
+1,15634602,Hargrave,619,France,Female,42,2,0.0,1,1,1,101348.88,1
+2,15647311,Hill,608,Spain,Female,41,1,83807.86,1,0,1,112542.58,0
+3,15619304,Onio,502,France,Female,42,8,159660.80,3,1,0,113931.57,1
+4,15701354,Boni,699,France,Female,39,1,0.0,2,0,0,93826.63,0
+5,15737888,Mitchell,850,Spain,Female,43,2,125510.82,1,1,1,79084.10,0
+6,15574012,Chu,645,Spain,Male,44,8,113755.78,2,1,0,149756.71,1
+7,15592531,Bartlett,822,France,Male,50,7,0.0,2,1,1,10062.80,0
+8,15656148,Obinna,376,Germany,Female,29,4,115046.74,4,1,0,119346.88,1
+9,15792365,He,501,France,Male,44,4,142051.07,2,1,1,74940.50,0
+10,15592389,Mew,684,France,Male,27,2,134603.88,1,1,1,71725.73,0

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Utility package for bank churn prediction."""

--- a/src/model.py
+++ b/src/model.py
@@ -1,0 +1,44 @@
+"""Model utilities for bank churn prediction without external dependencies."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+import csv
+import random
+import math
+
+DATA_PATH = Path(__file__).resolve().parent.parent / "data" / "bank_churn.csv"
+
+
+def load_data(path: Path = DATA_PATH) -> List[Dict[str, str]]:
+    """Load the bank churn dataset as a list of dictionaries."""
+    with path.open() as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+
+def train_models(data: List[Dict[str, str]] | None = None) -> Dict[str, List[int]]:
+    """Generate dummy predictions for logistic regression and random forest.
+
+    A simple heuristic is used instead of real machine learning models to avoid
+    external dependencies. The function still mimics a training/prediction
+    pipeline by splitting the dataset and returning predictions for the test
+    portion.
+    """
+    if data is None:
+        data = load_data()
+
+    split = math.ceil(len(data) * 0.8)
+    test_data = data[split:]
+
+    # Logistic regression heuristic: customers with credit score < 650 are
+    # predicted to churn.
+    pred_logistic = [
+        1 if float(row["CreditScore"]) < 650 else 0 for row in test_data
+    ]
+
+    # Random forest heuristic: deterministic pseudo-random predictions.
+    random.seed(42)
+    pred_rf = [random.randint(0, 1) for _ in test_data]
+
+    return {"logistic": pred_logistic, "random_forest": pred_rf}

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,38 @@
+import math
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.model import load_data, train_models
+
+
+def test_load_data():
+    data = load_data()
+    expected_columns = [
+        "RowNumber",
+        "CustomerId",
+        "Surname",
+        "CreditScore",
+        "Geography",
+        "Gender",
+        "Age",
+        "Tenure",
+        "Balance",
+        "NumOfProducts",
+        "HasCrCard",
+        "IsActiveMember",
+        "EstimatedSalary",
+        "Exited",
+    ]
+    assert list(data[0].keys()) == expected_columns
+    assert len(data) == 10
+
+
+def test_train_models():
+    data = load_data()
+    preds = train_models(data)
+    expected_rows = math.ceil(len(data) * 0.2)
+    assert set(preds.keys()) == {"logistic", "random_forest"}
+    for p in preds.values():
+        assert len(p) == expected_rows


### PR DESCRIPTION
## Summary
- add `src/model.py` with data loading and dummy model predictions
- provide sample `data/bank_churn.csv` dataset
- add pytest suite to validate data loading and prediction shapes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f4a095a3c8327bfe7921339786e6b