### PR TITLE
Add dataset and fix notebook data path

### DIFF
--- a/data/Bank Customer Churn Prediction.csv
+++ b/data/Bank Customer Churn Prediction.csv
@@ -1,0 +1,11 @@
+credit_score,country,gender,age,tenure,balance,products_number,credit_card,active_member,estimated_salary,churn
+619,France,Female,42,2,0,1,1,1,101348.88,1
+608,Spain,Female,41,1,83807.86,1,0,1,112542.58,0
+502,France,Female,42,8,159660.8,3,1,0,113931.57,1
+699,France,Female,39,1,0,2,0,0,93826.63,0
+850,Spain,Female,43,2,125510.82,1,1,1,79084.10,0
+645,Spain,Male,44,8,113755.78,2,1,0,149756.71,1
+822,France,Male,50,7,0,2,1,1,10062.80,0
+376,Germany,Female,29,4,115046.74,4,1,0,119346.88,1
+501,France,Male,44,4,142051.07,2,0,1,74940.50,0
+684,Spain,Male,27,6,134603.88,2,1,1,71725.73,0

--- a/notebook/bank_churn_prediction.ipynb
+++ b/notebook/bank_churn_prediction.ipynb
@@ -50,7 +50,7 @@
    "outputs": [],
    "source": [
     "\n",
-    "df = pd.read_csv('./data/Bank Customer Churn Prediction.csv')\n",
+    "df = pd.read_csv('../data/Bank Customer Churn Prediction.csv')\n",
     "\n",
     "# Label Encoding 處理類別欄位\n",
     "label = LabelEncoder()\n",


### PR DESCRIPTION
## Summary
- add sample Bank Customer Churn dataset under `data/`
- fix notebook to load dataset from correct relative path

## Testing
- `python - <<'PY'
try:
 import pandas as pd
 df = pd.read_csv('data/Bank Customer Churn Prediction.csv')
 print(df.head())
except Exception as e:
 print('error', e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_688f4a07ee40832787f00042bcd878cf