### PR TITLE
Fix dataset link formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,5 +116,3 @@ bank-churn-prediction/
 
 📁 資料來源：
 本專案使用之資料為 Kaggle 平台之開源資料集 [Bank Customer Churn Dataset](https://www.kaggle.com/datasets/gauravtopre/bank-customer-churn-dataset)，包含約 10,000 筆客戶資訊
-
-


### PR DESCRIPTION
## Summary
- ensure the Kaggle dataset link in the 資料來源 section stays on a single line

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f4a029d1083279d8e526d79624d8b